### PR TITLE
Introduce OperatorSampler

### DIFF
--- a/scripts/main.jl
+++ b/scripts/main.jl
@@ -65,7 +65,7 @@ function init_mc_cli(parsed_args)
 end
 
 
-function make_info_file(info_file, samples_file, mc_opts, observables, corr_time)
+function make_info_file(info_file, samples_file, mc_opts, op_list_length, observables, corr_time)
     M, MCS, EQ_MCS, skip = mc_opts
     mag, abs_mag, mag_sqr, energy = observables
 
@@ -80,7 +80,8 @@ function make_info_file(info_file, samples_file, mc_opts, observables, corr_time
 
             println(io, "Correlation time: $(corr_time)\n")
 
-            println(io, "Operator list length: $(2*M)")
+            println(io, "Initial Operator list length: $(2*M)")
+            println(io, "Final Operator list length: $(op_list_length)")
             println(io, "Number of MC measurements: $(MCS)")
             println(io, "Number of equilibration steps: $(EQ_MCS)")
             println(io, "Number of skips between measurements: $(skip)\n")
@@ -102,7 +103,9 @@ function save_data(path, mc_opts, qmc_state, measurements, observables, corr_tim
 
     @time @save qmc_state_file qmc_state
 
-    make_info_file(info_file, samples_file, mc_opts, observables, corr_time)
+    M = length(qmc_state.operator_list)
+
+    make_info_file(info_file, samples_file, mc_opts, M, observables, corr_time)
 end
 
 

--- a/src/QMC.jl
+++ b/src/QMC.jl
@@ -14,6 +14,8 @@ using DataStructures
 using SparseArrays
 
 import Base: zero
+import Base: length, size, eltype, setindex!, getindex, firstindex, lastindex, rand
+
 
 
 export BinaryQMCState, Hamiltonian, TFIM, nspins, nbonds, ClusterData, mc_step!, mc_step_beta!,
@@ -23,6 +25,7 @@ export BinaryQMCState, Hamiltonian, TFIM, nspins, nbonds, ClusterData, mc_step!,
 
 
 include("lattice.jl")
+include("op_sampler.jl")
 include("hamiltonian.jl")
 include("qmc_state.jl")
 include("measurements.jl")

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -4,32 +4,19 @@ localdim(::Hamiltonian{D}) where {D} = D
 dim(::Hamiltonian{D,N}) where {D,N} = N
 
 struct TFIM{N} <: Hamiltonian{2,N}
-    bond_spin::Vector{NTuple{2, Int}}
+    op_sampler::OperatorSampler{2, Float64}
     h::Float64
     J::Float64
-    P_h::Float64
-    P_J::Float64
     P_normalization::Float64
     Ns::Int
     Nb::Int
 end
 
 function TFIM(bond_spin, Dim::Int, Ns::Int, Nb::Int, h::Float64, J::Float64)
-    # bond_spin = lattice_bond_spins(lattice)
-
-    # Ns, Nb = length(lattice), length(bond_spin)
-
-    # define the Metropolis probability as a constant
-    # https://pitp.phas.ubc.ca/confs/sherbrooke2012/archives/Melko_SSEQMC.pdf
-    # equation 1.43
-    P_h = h * Ns
-    P_J = 2 * J * Nb
-
-    P_normalization = P_h + P_J
-    P_h /= P_normalization
-    P_J /= P_normalization
-
-    return TFIM{Dim}(bond_spin, h, J, P_h, P_J, P_normalization, Ns, Nb)
+    ops, p = make_prob_vector(bond_spin, Ns, J, h)
+    op_sampler = OperatorSampler(ops, p)
+    P_normalization = sum(p)
+    return TFIM{Dim}(op_sampler, h, J, P_normalization, Ns, Nb)
 end
 
 zero(H::Hamiltonian{2}) = falses(nspins(H))

--- a/src/op_sampler.jl
+++ b/src/op_sampler.jl
@@ -57,6 +57,10 @@ struct OperatorSampler{N, T <: Real}
     op_indices::Dict{NTuple{N, Int}, Int}
 end
 
+
+# samples operators using a heap
+# based on a blog post by Tim Vieira
+# https://timvieira.github.io/blog/post/2016/11/21/heaps-for-incremental-computation/
 function OperatorSampler(operators::Vector{NTuple{N, Int}}, p::AbstractVector{T}) where {N, T <: Real}
     L = length(p)
     d = 2 ^ ceil(Int, log2(L))

--- a/src/op_sampler.jl
+++ b/src/op_sampler.jl
@@ -4,27 +4,24 @@
 # (0, 0) = id
 # (i, j) = diag bond op
 
-
 function make_prob_vector(J::AbstractMatrix, hx::AbstractVector)
-    ops = repeat([(0, 0)], length(J) + length(hx))
-    p = zeros(length(ops))
+    ops = Vector{NTuple{2, Int}}(undef, 0)
+    p = Vector{Float64}(undef, 0)
 
     k = 0
     for i in eachindex(hx)
-        k += 1
         if hx[i] != 0
-            ops[k] = (-1, i)
-            p[k] = hx[i]
+            push!(ops, (-1, i))
+            push!(p, h)
         end
     end
 
     # only take J_ij terms from upper diagonal since it's symmetric
     for j in axes(J, 2), i in axes(J, 1)
         if i < j
-            k += 1
             if J[i, j] != 0
-                ops[k] = (i, j)
-                p[k] = 2*abs(J[i, j])
+                push!(ops, op)
+                push!(p, 2*abs(J))
             end
         end
     end
@@ -32,9 +29,32 @@ function make_prob_vector(J::AbstractMatrix, hx::AbstractVector)
     return ops, p
 end
 
-struct OperatorSampler{N}
+function make_prob_vector(bond_spins::Vector{NTuple{2,Int}}, Ns::Int, J, h)
+    ops = Vector{NTuple{2, Int}}(undef, 0)
+    p = Vector{Float64}(undef, 0)
+
+    if !iszero(h)
+        for i in 1:Ns
+            push!(ops, (-1, i))
+            push!(p, h)
+        end
+    end
+
+    if !iszero(J)
+        for op in bond_spins
+            push!(ops, op)
+            push!(p, 2*abs(J))
+        end
+    end
+
+    return ops, p
+end
+
+
+struct OperatorSampler{N, T <: Real}
     operators::Vector{NTuple{N, Int}}
-    prob_heap::Vector{Float64}
+    prob_heap::Vector{T}
+    op_indices::Dict{NTuple{N, Int}, Int}
 end
 
 function OperatorSampler(operators::Vector{NTuple{N, Int}}, p::AbstractVector{T}) where {N, T <: Real}
@@ -48,10 +68,42 @@ function OperatorSampler(operators::Vector{NTuple{N, Int}}, p::AbstractVector{T}
         heap[i] = heap[2*i] + heap[2*i + 1]
     end
 
-    return OperatorSampler{N}(operators, heap)
+    op_indices = Dict(op => i for (i, op) in enumerate(operators))
+
+    return OperatorSampler{N, T}(operators, heap, op_indices)
 end
 
-function rand(os::OperatorSampler)
+length(os::OperatorSampler) = length(os.operators)
+
+function setindex!(os::OperatorSampler, v::Float64, i::Int)
+    heap = os.prob_heap
+    l = length(heap)
+    j = (l÷2 - 1) + i
+    heap[j] = v
+    while j > 1
+        j ÷= 2
+        heap[j] = heap[2*j] + heap[2*j + 1]
+    end
+end
+
+function getindex(os::OperatorSampler, i::Int)
+    denom = os.prob_heap[1]
+    return os.prob_heap[(length(os.prob_heap) ÷ 2 - 1) + i] / denom
+end
+getindex(os::OperatorSampler{N}, op::NTuple{N, Int}) where N = os[os.op_indices[op]]
+
+function getindex(os::OperatorSampler, r::AbstractArray{Int})
+    denom = os.prob_heap[1]
+    d = (length(os.prob_heap) ÷ 2) - 1
+    return os.prob_heap[d .+ r] / denom
+end
+getindex(os::OperatorSampler{N}, ops::Vector{NTuple{N, Int}}) where N = os[os.op_indices[ops]]
+
+
+firstindex(::OperatorSampler) = 1
+lastindex(os::OperatorSampler) = length(os)
+
+function rand(os::OperatorSampler{N})::NTuple{N, Int} where N
     heap = os.prob_heap
     l = length(heap) ÷ 2
     r = rand() * heap[1]
@@ -65,7 +117,7 @@ function rand(os::OperatorSampler)
             i += 1
         end
     end
-    return os.operators[i - l + 1]
+    return os.operators[(i - l + 1)]
 end
 
 

--- a/src/updates.jl
+++ b/src/updates.jl
@@ -42,22 +42,27 @@ end
 mc_step_beta!(qmc_state, H, beta; eq = false) = mc_step_beta!((args...) -> nothing, qmc_state, H, beta; eq = eq)
 
 
-# returns true is operator insertion succeeded
+# returns true if operator insertion succeeded
 function insert_diagonal_operator!(qmc_state::BinaryQMCState, H::TFIM, spin_prop, n)
-    rr = rand()
-    if rr < H.P_h  # probability to choose a single-site operator
-        qmc_state.operator_list[n] = (-1, rand(1:H.Ns))
+    # rr = rand()
+    # if rr < H.P_h  # probability to choose a single-site operator
+    #     qmc_state.operator_list[n] = (-1, rand(1:H.Ns))
+    #     return true
+    # else
+    #     site1, site2 = H.bond_spin[rand(1:H.Nb)]
+    #     # spins at each end of the bond must be the same
+    #     if spin_prop[site1] == spin_prop[site2]
+    #         qmc_state.operator_list[n] = (site1, site2)
+    #         return true
+    #     end
+    # end
+    site1, site2 = rand(H.op_sampler)
+    if site1 < 0 || spin_prop[site1] == spin_prop[site2]
+        qmc_state.operator_list[n] = (site1, site2)
         return true
     else
-        site1, site2 = H.bond_spin[rand(1:H.Nb)]
-        # spins at each end of the bond must be the same
-        if spin_prop[site1] == spin_prop[site2]
-            qmc_state.operator_list[n] = (site1, site2)
-            return true
-        end
+        return false
     end
-
-    return false
 end
 
 


### PR DESCRIPTION
Using OperatorSampler is only marginally slower than the old method, in the case of a nearest neighbor (uniform interaction) with uniform transverse field: 

For a 10 site chain with PBC, operator list (full) length = 2000, taking 100'000 MC steps takes 45 sec, compared to 42 sec before this change.

Observable statistics are the same (i.e. within error bars), the only difference is due to slightly different randomization.

With the OperatorSampler, we should be able to do arbitrary interaction TFIM fairly easily (resolving #2). However, there's still optimizations which can be done. These usually amount to reducing the size of the probability vector in some way by making use of translation symmetries in the interactions + fields. 